### PR TITLE
add discord redirect under /discord path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  async redirects() {
+    return [
+      {
+        source: "/discord",
+        destination: "https://discord.gg/BHtvRaRr",
+        permanent: false,
+      },
+    ];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## What type of PR is this?

- - [ ] :bug: Bug Fix
- - [x] :package: Feature
- - [ ] :file_folder: Documentation
- - [ ] :rocket: Improvement
- - [ ] :white_check_mark: Test
- - [ ] :card_file_box: Database

## Description

- Add redirect from /discord to the pool discord server, can be used to add pretty links in emails under https://join.tomasinoweb.org/discord

## What did you do?

Use next.js path redirects (same as new code for lamona)
