### PR TITLE
improve navbar and add responsive button component

### DIFF
--- a/src/components/Buttons.module.scss
+++ b/src/components/Buttons.module.scss
@@ -1,156 +1,70 @@
-$manrope: "Manrope", sans-serif;
-$white: #ffffff;
-$dark-grey: #343332;
-$light-grey: hsl(30, 2%, 30%);
-$dark-blue: #3c778880;
+.black_n_white {
+  --border-color: var(--dark_grey);
+  --foreground-color: var(--dark_grey);
+  --background-color: white;
 
-.primary {
-  .buttonFrame {
-    display: flex;
-    width: 399px;
-    height: 81px;
-
-    padding: 24px 0px;
-    justify-content: center;
-    align-items: center;
-    flex-shrink: 0;
-    border: 2px solid var(--white, #fff);
-    background: var(--glass-bg, rgba(121, 163, 158, 0.5));
-
-    /* glassmorphism-blur */
-    backdrop-filter: blur(2px);
-  }
-
-  .buttonFrame:hover {
-    border: 2px solid var(--white, #fff);
-    background: rgba(60, 119, 136, 0.5);
-
-    /* glassmorphism-blur */
-    backdrop-filter: blur(2px);
-  }
-
-  .buttonText {
-    color: var(--white, #fff);
-    text-align: center;
-
-    /* 2px-text-shadow (25%) */
-    text-shadow: 2px 2px 0px rgba(0, 0, 0, 0.25);
-    font-family: $manrope;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: 700;
-    line-height: normal;
-    text-transform: uppercase;
-  }
-
-  @media (max-width: 1200px) {
-    .buttonFrame {
-      min-width: 180px;
-      height: 70px;
-      padding: 20px 0px;
-    }
-  }
-
-  @media (max-width: 992px) {
-    .buttonFrame {
-      min-width: 120px;
-      height: 60px;
-      padding: 16px 0px;
-    }
-  }
-
-  @media (max-width: 768px) {
-    .buttonFrame {
-      max-width: 80px;
-      height: 50px;
-      padding: 12px 0px;
-    }
-    .buttonText {
-      font-size: 20px;
-    }
-  }
-
-  @media (max-width: 576px) {
-    .buttonFrame {
-      max-width: 30px;
-      height: 40px;
-      padding: 8px 0px;
-    }
-    .buttonText {
-      font-size: 15px;
-    }
-  }
+  --hover-border-color: white;
+  --hover-foreground-color: white;
+  --hover-background-color: var(--dark_grey);
+  --text-shadow: none;
+  --font-family: Manrope-Medium, sans-serif;
 }
 
-.secondary {
-  .buttonFrame {
-    display: inline-flex;
-    padding: 24px 32px;
-    justify-content: center;
-    align-items: center;
-    gap: 10px;
+.glass {
+  --border-color: white;
+  --foreground-color: white;
+  --background-color: rgba(121, 163, 158, 0.5);
 
-    border: 2px solid var(--dark-grey, #343332);
-    background: var(--white, #fff);
+  --hover-border-color: white;
+  --hover-foreground-color: white;
+  --hover-background-color: rgba(60, 119, 136, 0.5);
+  --text-shadow: 2px 2px #00000040;
+  --font-family: Manrope-Bold, sans-serif;
+}
 
-    /* glassmorphism-blur */
-    backdrop-filter: blur(2px);
+.button {
+  height: 100%;
+  border: 2px solid var(--border-color);
+  width: fit-content;
+  background-color: var(--background-color);
+  color: var(--foreground-color);
+  text-decoration: none;
+  cursor: pointer;
+  text-shadow: var(--text-shadow);
+  transition: 150ms ease-in-out all;
+
+  padding: 24px;
+  font-family: var(--font-family);
+  font-size: 24px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button:hover {
+  background-color: var(--hover-background-color);
+  color: var(--hover-foreground-color);
+  border-color: var(--hover-border-color);
+  transition: 150ms ease-in-out all;
+}
+
+.maxWidth {
+  width: 100%;
+}
+
+.small {
+  padding: 12px 24px;
+}
+
+@media screen and (max-width: 700px) {
+  .button {
+    padding: 16px 36px;
+    font-size: 18px;
   }
 
-  .buttonFrame:hover {
-    border: 2px solid var(--white, #fff);
-    background: var(--dark-grey, #343332);
-    /* glassmorphism-blur */
-    backdrop-filter: blur(2px);
-
-    .buttonText {
-      color: var(--white, #fff);
-    }
-  }
-
-  .buttonText {
-    color: var(--dark-grey, #343332);
-    text-align: center;
-    font-family: $manrope;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: normal;
-    text-transform: uppercase;
-  }
-
-  @media (max-width: 1200px) {
-    .buttonFrame {
-      min-width: 180px;
-      height: 70px;
-      padding: 20px 0px;
-    }
-  }
-
-  @media (max-width: 992px) {
-    .buttonFrame {
-      min-width: 160px;
-      height: 60px;
-      padding: 16px 0px;
-    }
-  }
-
-  @media (max-width: 768px) {
-    .buttonFrame {
-      min-width: 140px;
-      height: 50px;
-      padding: 12px 0px;
-    }
-  }
-
-  @media (max-width: 576px) {
-    .buttonFrame {
-      max-width: 20px;
-      height: 40px;
-      padding: 8px 0px;
-    }
-    .buttonText {
-      font-size: 20px;
-    }
+  .small {
+    padding: 12px 24px;
+    font-size: 14px;
   }
 }

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -1,22 +1,57 @@
-import React, { useState } from "react";
+import React, { MouseEventHandler, useState } from "react";
 import styles from "./Buttons.module.scss";
+import Link from "next/link";
 
-interface ButtonsProps {
-  theme: string;
-  text: string;
-}
+type ButtonProps = {
+  children: React.ReactNode;
+  maxWidth?: boolean;
+} & ({ onClick: MouseEventHandler<HTMLButtonElement> | "submit" | "reset" } | { href: string }) &
+  ({ theme: "black_n_white"; outline?: "small" | "large" } | { theme: "glass" });
 
-const Buttons = (props: ButtonsProps) => {
-  const buttonClass = props.theme === "primary" ? styles.primary : styles.secondary;
+/**
+ * A Button component that supports both links and button
+ *
+ * ---
+ * **Using links vs buttons**
+ *
+ * To use as a link: Pass the href prop with the link to redict to
+ *
+ * To use as a button: Pass the onClick handler the function to call when clicked, or "reset" | "submit" when used in a form
+ *
+ * ---
+ * **Variants**
+ *
+ * To use glassy type: Pass "glass" into the theme prop
+ *
+ * To use black and white button: Pass "black_n_white" into the theme prop.
+ *
+ * To use small variant of BnW button: Pass "small" as outline prop
+ * @returns A button component
+ */
+export const Button = (props: ButtonProps) => {
+  const className =
+    styles[props.theme] +
+    " " +
+    (props.theme === "black_n_white" ? styles[props.outline ?? "large"] : "") +
+    " " +
+    styles.button +
+    " " +
+    (props.maxWidth ? styles.maxWidth : "");
+
+  if ("href" in props)
+    return (
+      <Link href={props.href} className={className}>
+        {props.children}
+      </Link>
+    );
 
   return (
-    <div className={buttonClass}>
-    <button className={`${styles.buttonFrame} ${buttonClass}`}>
-      <h3 className={`${styles.buttonText}`}>{props.text}</h3>
+    <button
+      onClick={typeof props.onClick === "function" ? props.onClick : undefined}
+      type={typeof props.onClick === "function" ? "button" : props.onClick}
+      className={className}
+    >
+      {props.children}
     </button>
-    </div>
-    
   );
 };
-
-export default Buttons;

--- a/src/components/Navbar.module.scss
+++ b/src/components/Navbar.module.scss
@@ -15,6 +15,7 @@ $manrope: "Manrope-Bold", sans-serif;
   z-index: 10;
   top: 0;
   left: 0;
+  backdrop-filter: blur(8px);
 
   p,
   a,
@@ -22,12 +23,14 @@ $manrope: "Manrope-Bold", sans-serif;
     text-shadow: var(--text-shadow);
   }
 
-  .logo {
+  .logo,
+  .logo a {
     font-family: $aesthetic, sans-serif;
     font-size: 24px;
     line-height: 1em;
     margin-bottom: -2px;
     color: var(--foreground);
+    text-decoration: none;
   }
 
   .inner {
@@ -72,6 +75,15 @@ $manrope: "Manrope-Bold", sans-serif;
       padding: 10px 20px;
       border: 2.5px solid var(--foreground);
       background: none;
+      transition: 200ms ease-in-out all;
+    }
+
+    .button:hover {
+      border: 2.5px solid var(--foreground) !important;
+      background: var(--hover-background);
+      border-color: var(--border);
+      color: var(--hover-foreground);
+      transition: 200ms ease-in-out all;
     }
   }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,7 +47,9 @@ export default function Navbar({ background_color: color, type }: NavbarProps) {
     return (
       <header className={(isOpened ? styles.isOpened : "") + " " + headerClass + " " + styles.full}>
         <div className={styles.inner + " " + styles.jcsb}>
-          <h1 className={styles.logo}>STUDIO TOMWEB</h1>
+          <h1 className={styles.logo}>
+            <Link href="/">STUDIO TOMWEB</Link>
+          </h1>
 
           <div className={styles.right}>
             <div className={styles.desktop}>

--- a/src/layouts/public/styles.module.scss
+++ b/src/layouts/public/styles.module.scss
@@ -6,12 +6,18 @@
   --foreground: white;
   --background: radial-gradient(98.05% 261.61% at 1.95% 3.59%, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.4) 100%);
   --text-shadow: 2px 2px #00000040;
+  --hover-foreground: white;
+  --hover-background: #3c7788;
+  --border: white;
 }
 
 .not_transparent {
   --foreground: #343332;
   --background: white;
   --text-shadow: none;
+  --hover-foreground: white;
+  --hover-background: var(--dark_grey);
+  --border: white;
 }
 
 .flex {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from "../components/Buttons";
 import { PublicLayoutFrontend } from "../layouts/public/frontend";
 import { PublicLayoutBackend } from "../layouts/public/static";
 import styles from "./index.module.scss";
@@ -11,11 +12,40 @@ export default PublicLayoutFrontend.use<PageProps>(() => {
 
     children: (
       <div>
-        <div>
-          <img
-            className={styles.image}
-            src="https://images.unsplash.com/photo-1724250267025-08b545ab90dc?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-          />
+        <div style={{ display: "flex", flexDirection: "row", gap: "10px" }}>
+          <div style={{ maxWidth: "500px", flex: 1 }}>
+            <Button href="/quiz" theme="black_n_white" maxWidth>
+              <p>QUIZ</p>
+            </Button>
+          </div>
+
+          <div style={{ maxWidth: "500px", flex: 1 }}>
+            <Button onClick={() => alert("Testing")} theme="glass" maxWidth>
+              <p>CLICK ME FOR ALERT</p>
+            </Button>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "row", gap: "10px" }}>
+          <div style={{ maxWidth: "500px", flex: 1 }}>
+            <Button href="/quiz" theme="black_n_white">
+              <p>QUIZ</p>
+            </Button>
+          </div>
+
+          <div style={{ maxWidth: "500px", flex: 1 }}>
+            <Button href="/quiz" theme="glass">
+              <p>QUIZ</p>
+            </Button>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "row", gap: "10px" }}>
+          <div style={{ maxWidth: "500px", flex: 1 }}>
+            <Button href="/quiz" theme="black_n_white" outline="small">
+              <p>QUIZ</p>
+            </Button>
+          </div>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Description and Changes

 - Improve navbar by finally adding blur (hindi ko nakita) when using transparent layouts
 
![image](https://github.com/user-attachments/assets/5a11104d-1b89-4323-b078-5554216bc838)
 
 - Add responsive button component that can be used as either Link or Button

**Desktop** 
![image](https://github.com/user-attachments/assets/098d2553-2537-470c-b99c-c4015b367f44)

**Mobile**
![image](https://github.com/user-attachments/assets/f6e81cf0-36f2-417a-8020-4bdca9977b08)

## Docs are provided when hovering over the Button component, copied here.

**Using links vs buttons**
 - To use as a link: Pass the href prop with the link to redict to
 - To use as a button: Pass the onClick handler the function to call when clicked, or "reset" | "submit" when used in a form

---

**Variants**
 - To use glassy type: Pass "glass" into the theme prop
 - To use black and white button: Pass "black_n_white" into the theme prop.
 - To use small variant of BnW button: Pass "small" as outline prop
 
By default, the button will take the minimum width it can to show its contents in 1 line, to make it take the entire width of its parent, pass the `maxWidth` prop. The parent is responsive to properly size the component, the component itself never assumes any single size.

Closes #79 