### PR TITLE
fixed loading mascot dimension on mobile devices

### DIFF
--- a/src/components/Loading.module.scss
+++ b/src/components/Loading.module.scss
@@ -27,6 +27,8 @@
 .mascotIcon {
   position: absolute;
   top: calc(50% + 8px);
+  width: 31px;
+  height: auto;
 }
 
 /* Spinner and animations */


### PR DESCRIPTION
## Description

- Fixed dimensions of mascot.png in loading screen

## What did you do?

Before:
![image](https://github.com/user-attachments/assets/2d8f1e1d-18b5-4dba-9107-ef970acbd108)

After:
![image](https://github.com/user-attachments/assets/320b92f2-9b97-4c26-bb95-4a25ad25718d)
