### PR TITLE
The ghibli icons should be centered vertically

### DIFF
--- a/src/pages/faq.module.scss
+++ b/src/pages/faq.module.scss
@@ -59,6 +59,8 @@ $manrope: "Manrope-Bold", sans-serif;
   padding: 16.5px 16px;
   user-select: none;
   height: 78px;
+  justify-content: center;
+  align-items: center;
 }
 
 .mobile-cell1 {
@@ -94,7 +96,10 @@ $manrope: "Manrope-Bold", sans-serif;
 }
 
 .faq-icons {
-  height: calc(10px + 1vw);
+  height: calc(30px + 1vw);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .faq-head {
@@ -222,6 +227,9 @@ $manrope: "Manrope-Bold", sans-serif;
 }
 
 @media only screen and (max-width: 770px) {
+  .faq-icons {
+    height: calc(25px + 1vw);
+  }
   .faq-main-holder {
     display: grid;
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Description

- The ghibli icons should be centered vertically
- adjust the asset size and position
from :
![image](https://github.com/user-attachments/assets/4ccbea84-96eb-4441-9de8-ac79d293dd66)

to:
![image](https://github.com/user-attachments/assets/c2ca99f8-f9b1-4abe-8b34-04cdc560c25c)

